### PR TITLE
Fix broken link to Bonsai's URI parsing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ URI Parsing is a library for building composable URI parsers using
 [ppx_typed_fields](https://github.com/janestreet/ppx_typed_fields).
 
 See the Bonsai Guide [chapter on
-urls](https://github.com/janestreet/bonsai/blob/master/docs/how_to/uri_parsing.md).
+urls](https://github.com/janestreet/bonsai_web/blob/master/docs/how_to/uri_parsing.md).
 This library contains the "typed" parsing/unparsing module for URL Var. The
 reason that this library exists as a separate library is that URL Var has a
 JavaScript browser dependency which makes it unable to run outside of a JavaScript


### PR DESCRIPTION
This project's README had a link to a Bonsai guide that seems to have moved to a new location.
Thus this PR replaces the link with what appears to be the new location of the Bonsai docs.